### PR TITLE
fix(routes): Pass `next` to `passport.authenticate`

### DIFF
--- a/routes/connect.js
+++ b/routes/connect.js
@@ -36,7 +36,7 @@ module.exports = function (server) {
         passport.authenticate(provider, {
           scope: config.scope,
           state: req.authorizationId
-        })(req, res);
+        })(req, res, next);
       }
 
       // NOT FOUND


### PR DESCRIPTION
Fixes issue where the `authenticate` handler may fail when trying to reference `next`, which is undefined unless passed as a parameter.

Example stack trace:

```text
anvil-connect/node_modules/passport/lib/middleware/authenticate.js:336
        next(err);
        ^
TypeError: next is not a function
    at OAuthStrategy.strategy.error (anvil-connect/node_modules/passport/lib/middleware/authenticate.js:336:9)
    at anvil-connect/protocols/OAuth.js:552:25
    at anvil-connect/protocols/OAuth.js:346:14
    at Request.callback (anvil-connect/node_modules/superagent/lib/node/index.js:797:3)
    at Stream.<anonymous> (anvil-connect/node_modules/superagent/lib/node/index.js:990:12)
    at emitNone (events.js:72:20)
    at Stream.emit (events.js:166:7)
    at Unzip.<anonymous> (anvil-connect/node_modules/superagent/lib/node/utils.js:108:12)
    at emitNone (events.js:72:20)
    at Unzip.emit (events.js:166:7)
```