### PR TITLE
Update to match express v4 API

### DIFF
--- a/routes/register.js
+++ b/routes/register.js
@@ -68,7 +68,7 @@ module.exports = function (server) {
             'Pragma': 'no-cache'
           });
 
-          res.json(201, client.configuration(settings, token));
+          res.status(201).json(client.configuration(settings, token));
         });
       });
     });

--- a/routes/userinfo.js
+++ b/routes/userinfo.js
@@ -30,7 +30,7 @@ module.exports = function (server) {
       User.get(req.claims.sub, function (err, user) {
         if (err)   { return next(err); }
         if (!user) { return next(new NotFoundError()); }
-        res.json(200, user.project('userinfo'));
+        res.status(200).json(user.project('userinfo'));
       });
     });
 


### PR DESCRIPTION
Uses `res.status(code).func(...)` instead of `res.func(statusCode, ...)`