### PR TITLE
Fix callback function name

### DIFF
--- a/oidc/verifyAuthorizationCode.js
+++ b/oidc/verifyAuthorizationCode.js
@@ -18,7 +18,7 @@ function verifyAuthorizationCode (req, res, next) {
   if (params.grant_type === 'authorization_code') {
 
     AuthorizationCode.getByCode(params.code, function (err, ac) {
-      if (err) { return callback(err); }
+      if (err) { return next(err); }
 
       // Can't find authorization code
       if (!ac) {


### PR DESCRIPTION
`callback` is not defined in this context. Instead, the correct function to use is `next` (see `verifyAuthorizationCode` parameters)