### PR TITLE
Allow views to be overridden individually.

### DIFF
--- a/boot/server.js
+++ b/boot/server.js
@@ -40,9 +40,15 @@ module.exports = function (server) {
    */
 
   var engine = settings.view_engine || 'jade';
-  server.engine(engine,       cons[engine]);
-  server.set('views',         path.join(cwd, 'views'));
-  server.set('view engine',  engine);
+  server.engine(engine, cons[engine]);
+  server.set('view engine', engine);
+
+  // First, look for views in the project directory.
+  // If absent, look in the package views directory.
+  server.set('views', [
+    path.join(cwd, 'views'),
+    path.join(__dirname, '..', 'views')
+  ]);
 
 
   /**


### PR DESCRIPTION
Previously, views were loaded exclusively from the project directory. Now views are loaded from the package views directory by default and can be overridden individually from the project views directory, if necessary. This simplifies setup because we don't need to generate views as part of initializing the project.