### PR TITLE
fix(oidc): set amr values consistently

### DIFF
--- a/oidc/index.js
+++ b/oidc/index.js
@@ -30,6 +30,7 @@ var oidc = {
   session: require('./session'),
   sessionEvents: require('./sessionEvents'),
   sessionState: require('./sessionState'),
+  setSessionAmr: require('./setSessionAmr'),
   signout: require('./signout'),
   stashParams: require('./stashParams'),
   token: require('./token'),

--- a/oidc/setSessionAmr.js
+++ b/oidc/setSessionAmr.js
@@ -1,0 +1,24 @@
+/**
+ * Set Session `amr` claim
+ *
+ * The `amr` claim is an OIDC ID Token property
+ * used to indicate the type(s) of authentication
+ * for the current session. This value is set when
+ * users authenticate.
+ */
+
+function setSessionAmr (session, amr) {
+  if (amr) {
+    if (!Array.isArray(amr)) {
+      session.amr = [amr]
+    } else if (session.amr.indexOf(amr) === -1) {
+      session.amr.push(amr)
+    }
+  }
+}
+
+/**
+ * Export
+ */
+
+module.exports = setSessionAmr

--- a/routes/connect.js
+++ b/routes/connect.js
@@ -68,8 +68,10 @@ module.exports = function (server) {
           // login the user
           } else {
             req.login(user, function (err) {
+              if (err) { return next(err) }
+              oidc.setSessionAmr(req.session, req.provider.amr)
               req.session.opbs = crypto.randomBytes(256).toString('hex')
-              next(err)
+              next()
             })
           }
         })(req, res, next)

--- a/routes/signin.js
+++ b/routes/signin.js
@@ -75,16 +75,10 @@ module.exports = function (server) {
             })
           } else {
             req.login(user, function (err) {
-              req.session.amr = req.session.amr || []
-              var samr = req.session.amr
-              var pamr = req.provider.amr
-
-              if (pamr && samr.indexOf(pamr) === -1) {
-                req.session.amr.push(pamr)
-              }
-
+              if (err) { return next(err) }
+              oidc.setSessionAmr(req.session, req.provider.amr)
               req.session.opbs = crypto.randomBytes(256).toString('hex')
-              next(err)
+              next()
             })
           }
         })(req, res, next)

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -7,6 +7,7 @@
 var oidc = require('../oidc')
 var settings = require('../boot/settings')
 var passwordProvider = require('../providers').password
+var crypto = require('crypto')
 var passport = require('passport')
 var qs = require('qs')
 var User = require('../models/User')
@@ -54,15 +55,8 @@ module.exports = function (server) {
           } else {
             req.login(user, function (err) {
               if (err) { return next(err) }
-
-              req.session.amr = req.session.amr || []
-              var samr = req.session.amr
-              var pamr = req.provider.amr
-
-              if (pamr && samr.indexOf(pamr) === -1) {
-                req.session.amr.push(pamr)
-              }
-
+              oidc.setSessionAmr(req.session, req.provider.amr)
+              req.session.opbs = crypto.randomBytes(256).toString('hex')
               req.sendVerificationEmail =
                 req.provider.emailVerification.enable
               req.flash('isNewUser', true)


### PR DESCRIPTION
We now set amr values consistently at the signin, signup and connect
endpoints. Empty amr arrays are no longer added to the session.