### PR TITLE
Remove passport dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ public/vendor
 dump.rdb
 appendonly.aof
 npm-debug.log
+.settings

--- a/boot/passport.js
+++ b/boot/passport.js
@@ -86,11 +86,11 @@ exports.authenticate = function (provider, req, res, next, options, callback) {
 }
 
 exports.login = function (req, user) {
-  req.session.user = user._id
   oidc.setSessionAmr(req.session, req.provider.amr)
 
   // only update the OP Browser State if the user is not already logged in
-  if (!req.user) {
+  if (req.session.user !== user._id) {
+    req.session.user = user._id
     req.session.opbs = crypto.randomBytes(256).toString('hex')
   }
 }

--- a/boot/passport.js
+++ b/boot/passport.js
@@ -88,7 +88,11 @@ exports.authenticate = function (provider, req, res, next, options, callback) {
 exports.login = function (req, user) {
   req.session.user = user._id
   oidc.setSessionAmr(req.session, req.provider.amr)
-  req.session.opbs = crypto.randomBytes(256).toString('hex')
+
+  // only update the OP Browser State if the user is not already logged in
+  if (!req.user) {
+    req.session.opbs = crypto.randomBytes(256).toString('hex')
+  }
 }
 
 exports.logout = function (req) {

--- a/boot/passport.js
+++ b/boot/passport.js
@@ -2,39 +2,98 @@
  * Passport Configuration
  */
 
+var crypto = require('crypto')
 var settings = require('./settings')
 var providers = require('../providers')
 var protocols = require('../protocols')
+var oidc = require('../oidc')
 var User = require('../models/User')
 
-module.exports = function (passport) {
-  /**
-   * Sessions
-   */
+var strategies = {}
 
-  passport.serializeUser(function (user, done) {
-    done(null, user._id)
+exports.registerProviders = function () {
+  Object.keys(settings.providers).forEach(function (id) {
+    var providerConf = settings.providers[id]
+    var provider = providers[id] ? providers[id] : providerConf
+
+    var strategy = protocols.initialize(id, provider, providerConf)
+    strategies[id] = strategy
   })
+}
 
-  passport.deserializeUser(function (id, done) {
-    User.get(id, function (err, user) {
-      done(err, user)
-    })
-  })
+exports.authenticate = function (provider, req, res, next, options, callback) {
+  var baseStrategy = strategies[provider]
 
-  /**
-   * Strategies
-   */
-
-  if (settings.providers) {
-    Object.keys(settings.providers).forEach(function (id) {
-      var providerConf = settings.providers[id]
-      var provider = providers[id] ? providers[id] : providerConf
-
-      var strategy = protocols.initialize(id, provider, providerConf)
-      strategy.name = id
-      passport.use(strategy)
-    })
+  if (!baseStrategy) {
+    var cb = callback || next
+    return cb(new Error(
+      'No strategy defined for provider \'' +
+      provider + '\''
+    ))
   }
 
+  if (!callback) {
+    callback = options
+    options = undefined
+  }
+
+  var strategy = Object.create(baseStrategy)
+
+  strategy.success = function (user, info) {
+    req.user = user
+    if (callback) {
+      callback(null, user, info)
+    } else {
+      next()
+    }
+  }
+
+  strategy.fail = function (info, status) {
+    if (callback) {
+      callback(null, null, info)
+    } else {
+      User.get(req.session.user, function (err, user) {
+        if (err) {
+          return strategy.error(err)
+        }
+        if (!user) {
+          delete req.session.user
+          return next()
+        }
+        req.user = user
+        next()
+      })
+    }
+  }
+
+  strategy.pass = function () {
+    next()
+  }
+
+  strategy.error = function (err) {
+    if (callback) {
+      callback(err)
+    } else {
+      next(err)
+    }
+  }
+
+  strategy.redirect = function (url, status) {
+    res.redirect(status || 302, url)
+  }
+
+  strategy.authenticate(req, options)
+}
+
+exports.login = function (req, user) {
+  req.session.user = user._id
+  oidc.setSessionAmr(req.session, req.provider.amr)
+  req.session.opbs = crypto.randomBytes(256).toString('hex')
+}
+
+exports.logout = function (req) {
+  req.user = null
+  delete req.session.user
+  req.session.opbs = crypto.randomBytes(256).toString('hex')
+  delete req.session.amr
 }

--- a/boot/server.js
+++ b/boot/server.js
@@ -9,7 +9,7 @@ var client = require('./redis').getClient()
 var logger = require('./logger')(settings.logger)
 require('./mailer').getMailer()
 require('./database')()
-var passport = require('./passport')
+var authenticator = require('../lib/authenticator')
 var express = require('express')
 var cons = require('consolidate')
 var cookieParser = require('cookie-parser')
@@ -91,12 +91,12 @@ module.exports = function (server) {
    */
 
   server.use(connectFlash())
-  
+
   /**
    * Set user on request
    */
-   
-  server.use(passport.setUserOnRequest)
+
+  server.use(authenticator.setUserOnRequest)
 
   /**
    * Cross-Origin Support

--- a/boot/server.js
+++ b/boot/server.js
@@ -9,6 +9,7 @@ var client = require('./redis').getClient()
 var logger = require('./logger')(settings.logger)
 require('./mailer').getMailer()
 require('./database')()
+var passport = require('./passport')
 var express = require('express')
 var cons = require('consolidate')
 var cookieParser = require('cookie-parser')
@@ -90,6 +91,12 @@ module.exports = function (server) {
    */
 
   server.use(connectFlash())
+  
+  /**
+   * Set user on request
+   */
+   
+  server.use(passport.setUserOnRequest)
 
   /**
    * Cross-Origin Support

--- a/boot/server.js
+++ b/boot/server.js
@@ -10,7 +10,6 @@ var logger = require('./logger')(settings.logger)
 require('./mailer').getMailer()
 require('./database')()
 var express = require('express')
-var passport = require('passport')
 var cons = require('consolidate')
 var cookieParser = require('cookie-parser')
 var bodyParser = require('body-parser')
@@ -91,13 +90,6 @@ module.exports = function (server) {
    */
 
   server.use(connectFlash())
-
-  /**
-   * Passport Authentication Middleware
-   */
-
-  server.use(passport.initialize())
-  server.use(passport.session())
 
   /**
    * Cross-Origin Support

--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -1,17 +1,31 @@
 /**
- * Passport Configuration
+ * Module dependencies
  */
 
 var crypto = require('crypto')
-var settings = require('./settings')
+var settings = require('../boot/settings')
 var providers = require('../providers')
 var protocols = require('../protocols')
-var oidc = require('../oidc')
+var setSessionAmr = require('../oidc/setSessionAmr')
 var User = require('../models/User')
+
+/**
+ * Strategies
+ */
 
 var strategies = {}
 
-exports.registerProviders = function () {
+/**
+ * Authenticator
+ */
+
+function Authenticator () {}
+
+/**
+ * Register Providers
+ */
+
+function registerProviders () {
   Object.keys(settings.providers).forEach(function (id) {
     var providerConf = settings.providers[id]
     var provider = providers[id] ? providers[id] : providerConf
@@ -21,6 +35,8 @@ exports.registerProviders = function () {
   })
 }
 
+Authenticator.registerProviders = registerProviders
+
 /**
  * Set req.user
  */
@@ -29,7 +45,7 @@ function setUserOnRequest (req, res, next) {
   if (!req.session.user) {
     return next()
   }
-  
+
   User.get(req.session.user, function (err, user) {
     if (err) {
       return next(err)
@@ -42,9 +58,14 @@ function setUserOnRequest (req, res, next) {
     next()
   })
 }
-exports.setUserOnRequest = setUserOnRequest
 
-exports.authenticate = function (provider, req, res, next, options, callback) {
+Authenticator.setUserOnRequest = setUserOnRequest
+
+/**
+ * Dispatch
+ */
+
+function dispatch (provider, req, res, next, options, callback) {
   var baseStrategy = strategies[provider]
 
   if (!baseStrategy) {
@@ -98,8 +119,14 @@ exports.authenticate = function (provider, req, res, next, options, callback) {
   strategy.authenticate(req, options)
 }
 
-exports.login = function (req, user) {
-  oidc.setSessionAmr(req.session, req.provider.amr)
+Authenticator.dispatch = dispatch
+
+/**
+ * Login
+ */
+
+function login (req, user) {
+  setSessionAmr(req.session, req.provider.amr)
 
   // only update the OP Browser State if the user is not already logged in
   if (req.session.user !== user._id) {
@@ -108,9 +135,23 @@ exports.login = function (req, user) {
   }
 }
 
-exports.logout = function (req) {
+Authenticator.login = login
+
+/**
+ * Logout
+ */
+
+function logout (req) {
   req.user = null
   delete req.session.user
   req.session.opbs = crypto.randomBytes(256).toString('hex')
   delete req.session.amr
 }
+
+Authenticator.logout = logout
+
+/**
+ * Exports
+ */
+
+module.exports = Authenticator

--- a/oidc/authenticateUser.js
+++ b/oidc/authenticateUser.js
@@ -31,7 +31,7 @@ function authenticateUser (req, res, next) {
     })
 
   // User is not authenticated.
-  } else if (!req.isAuthenticated()) {
+  } else if (!req.user) {
     next(new UnauthorizedError({
       statusCode: 401
     }))

--- a/oidc/checkSession.js
+++ b/oidc/checkSession.js
@@ -30,6 +30,7 @@ function checkSession (req, res, next) {
       }, 3000)
     })
   }
+  compareOpbs()
 }
 
 /**

--- a/oidc/checkSession.js
+++ b/oidc/checkSession.js
@@ -10,22 +10,26 @@ var client = require('../boot/redis').getClient()
 
 function checkSession (req, res, next) {
   var initialOpbs = req.session.opbs
-  client.get('sess:' + req.sessionID, function (err, data) {
-    if (err) { return next(err) }
-    if (data) {
-      try {
-        var opbs = JSON.parse(data).opbs
-        if (opbs !== initialOpbs) {
-          res.write('event: update\n')
-          res.write('data: ' + opbs + '\n\n')
-        }
-      } catch (e) {}
-    }
 
-    setTimeout(function () {
-      checkSession(req, res)
-    }, 3000)
-  })
+  function compareOpbs () {
+    client.get('sess:' + req.sessionID, function (err, data) {
+      if (err) { return next(err) }
+      if (data) {
+        try {
+          var opbs = JSON.parse(data).opbs
+          if (opbs !== initialOpbs) {
+            res.write('event: update\n')
+            res.write('data: ' + opbs + '\n\n')
+            initialOpbs = opbs
+          }
+        } catch (e) {}
+      }
+
+      setTimeout(function () {
+        compareOpbs()
+      }, 3000)
+    })
+  }
 }
 
 /**

--- a/oidc/checkSession.js
+++ b/oidc/checkSession.js
@@ -12,13 +12,15 @@ function checkSession (req, res, next) {
   var initialOpbs = req.session.opbs
   client.get('sess:' + req.sessionID, function (err, data) {
     if (err) { return next(err) }
-    try {
-      var opbs = JSON.parse(data).opbs
-      if (opbs !== initialOpbs) {
-        res.write('event: update\n')
-        res.write('data: ' + opbs + '\n\n')
-      }
-    } catch (e) {}
+    if (data) {
+      try {
+        var opbs = JSON.parse(data).opbs
+        if (opbs !== initialOpbs) {
+          res.write('event: update\n')
+          res.write('data: ' + opbs + '\n\n')
+        }
+      } catch (e) {}
+    }
 
     setTimeout(function () {
       checkSession(req, res)

--- a/oidc/requireSignin.js
+++ b/oidc/requireSignin.js
@@ -18,14 +18,14 @@ function requireSignin (req, res, next) {
 
   // redirect with error if unauthenticated
   // and prompt is "none"
-  if (!req.isAuthenticated() && prompt === 'none') {
+  if (!req.user && prompt === 'none') {
     res.redirect(req.connectParams.redirect_uri + responseMode + qs.stringify({
       error: 'login_required',
       session_state: sessionState(req.client, req.client.client_uri, req.session.opbs)
     }))
 
   // prompt to sign in
-  } else if (!req.isAuthenticated() || prompt === 'login') {
+  } else if (!req.user || prompt === 'login') {
     res.redirect('/signin?' + qs.stringify(req.connectParams))
 
   // do not prompt to sign in

--- a/oidc/sessionEvents.js
+++ b/oidc/sessionEvents.js
@@ -9,7 +9,7 @@ var checkSession = require('./checkSession')
  */
 
 function sessionEvents (req, res) {
-  req.socket.setTimeout(Infinity)
+  req.socket.setTimeout(0)
 
   // Headers
   res.writeHead(200, {

--- a/oidc/signout.js
+++ b/oidc/signout.js
@@ -55,11 +55,6 @@ function signout (req, res, next) {
       return next(new InvalidTokenError("Can't decode id_token_hint"))
     }
 
-  // there's no way to verify the uri
-  } else if (uri) {
-    passport.logout(req)
-    res.redirect(uri)
-
   // logout and respond without redirect
   } else {
     passport.logout(req)

--- a/oidc/signout.js
+++ b/oidc/signout.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var passport = require('../boot/passport')
+var authenticator = require('../lib/authenticator')
 var settings = require('../boot/settings')
 var Client = require('../models/Client')
 var IDToken = require('../models/IDToken')
@@ -15,49 +15,39 @@ var InvalidTokenError = require('../errors/InvalidTokenError')
 function signout (req, res, next) {
   var uri = req.query.post_logout_redirect_uri
   var hint = req.query.id_token_hint
+  var token = uri && hint && IDToken.decode(hint, settings.keys.sig.pub)
 
   // verify the uri using the hint
-  if (uri && hint) {
-    var token = IDToken.decode(hint, settings.keys.sig.pub)
+  if (token && token instanceof Error === false) {
+    Client.get(token.payload.aud, function (err, client) {
+      var uris = client && client.post_logout_redirect_uris
 
-    // the token checks out
-    if (token && token instanceof Error === false) {
-      Client.get(token.payload.aud, function (err, client) {
-        // something smells bad
-        if (err) {
-          return next(err)
+      // something smells bad
+      if (err) {
+        return next(err)
 
-        // unknown client
-        } else if (!client) {
-          return next(new Error('Unknown client'))
+      // unknown client, or the uri is not registered.
+      // logout, but don't redirect.
+      } else if (!uris || uris.indexOf(uri) === -1) {
+        authenticator.logout(req)
 
-        // the uri is not registered.
-        // logout, but don't redirect.
-        } else if (client.post_logout_redirect_uris.indexOf(uri) === -1) {
-          passport.logout(req)
+        res.set({
+          'Cache-Control': 'no-store',
+          'Pragma': 'no-cache'
+        })
 
-          res.set({
-            'Cache-Control': 'no-store',
-            'Pragma': 'no-cache'
-          })
+        res.sendStatus(204)
 
-          res.sendStatus(204)
-
-        // logout and redirect
-        } else {
-          passport.logout(req)
-          res.redirect(uri)
-        }
-      })
-
-    // can't decode the token
-    } else {
-      return next(new InvalidTokenError("Can't decode id_token_hint"))
-    }
+      // logout and redirect
+      } else {
+        authenticator.logout(req)
+        res.redirect(uri)
+      }
+    })
 
   // logout and respond without redirect
   } else {
-    passport.logout(req)
+    authenticator.logout(req)
 
     res.set({
       'Cache-Control': 'no-store',

--- a/oidc/signout.js
+++ b/oidc/signout.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var crypto = require('crypto')
+var passport = require('../boot/passport')
 var settings = require('../boot/settings')
 var Client = require('../models/Client')
 var IDToken = require('../models/IDToken')
@@ -34,9 +34,7 @@ function signout (req, res, next) {
         // the uri is not registered.
         // logout, but don't redirect.
         } else if (client.post_logout_redirect_uris.indexOf(uri) === -1) {
-          req.session.opbs = crypto.randomBytes(256).toString('hex')
-          delete req.session.amr
-          req.logout()
+          passport.logout(req)
 
           res.set({
             'Cache-Control': 'no-store',
@@ -47,9 +45,7 @@ function signout (req, res, next) {
 
         // logout and redirect
         } else {
-          req.session.opbs = crypto.randomBytes(256).toString('hex')
-          delete req.session.amr
-          req.logout()
+          passport.logout(req)
           res.redirect(uri)
         }
       })
@@ -61,16 +57,12 @@ function signout (req, res, next) {
 
   // there's no way to verify the uri
   } else if (uri) {
-    req.session.opbs = crypto.randomBytes(256).toString('hex')
-    delete req.session.amr
-    req.logout()
+    passport.logout(req)
     res.redirect(uri)
 
   // logout and respond without redirect
   } else {
-    req.session.opbs = crypto.randomBytes(256).toString('hex')
-    delete req.session.amr
-    req.logout()
+    passport.logout(req)
 
     res.set({
       'Cache-Control': 'no-store',

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "modinha": "0.0.30",
     "modinha-redis": "0.0.21",
     "nodemailer": "^1.4.0",
-    "passport": "^0.3.0",
     "passport-adauth": "^0.1.2",
     "passport-ldapauth": "^0.3.0",
     "passport-local": "~1.0.0",

--- a/public/javascript/session.js
+++ b/public/javascript/session.js
@@ -6,7 +6,8 @@
    */
 
   var re = new RegExp('[; ]anvil.connect.op.state=([^\\s;]*)')
-  var opbs = document.cookie.match(re).pop()
+  var stateCookie = document.cookie.match(re)
+  var opbs = stateCookie && stateCookie.pop()
   var localStorage = window.localStorage
   var EventSource = window.EventSource
   var CryptoJS = window.CryptoJS

--- a/public/javascript/session.js
+++ b/public/javascript/session.js
@@ -5,7 +5,7 @@
    * Initialize browser state
    */
 
-  var re = new RegExp('[; ]anvil.connect.op.state=([^\\s;]*)')
+  var re = /\banvil\.connect\.op\.state=([^\s;]*)/
   var stateCookie = document.cookie.match(re)
   var opbs = stateCookie && stateCookie.pop()
   var localStorage = window.localStorage

--- a/routes/connect.js
+++ b/routes/connect.js
@@ -4,7 +4,7 @@
 
 var settings = require('../boot/settings')
 var oidc = require('../oidc')
-var passport = require('../boot/passport')
+var authenticator = require('../lib/authenticator')
 var qs = require('qs')
 var NotFoundError = require('../errors/NotFoundError')
 
@@ -29,7 +29,7 @@ module.exports = function (server) {
 
       // Authorize
       if (config) {
-        passport.authenticate(provider, req, res, next, {
+        authenticator.dispatch(provider, req, res, next, {
           scope: config.scope,
           state: req.authorizationId
         })
@@ -52,7 +52,7 @@ module.exports = function (server) {
 
     function (req, res, next) {
       if (settings.providers[req.params.provider]) {
-        passport.authenticate(req.params.provider, req, res, next, function (err, user, info) {
+        authenticator.dispatch(req.params.provider, req, res, next, function (err, user, info) {
           if (err) { return next(err) }
 
           // render the signin screen with an error
@@ -66,7 +66,7 @@ module.exports = function (server) {
 
           // login the user
           } else {
-            passport.login(req, user)
+            authenticator.login(req, user)
             next()
           }
         })

--- a/routes/signin.js
+++ b/routes/signin.js
@@ -5,7 +5,7 @@
 var oidc = require('../oidc')
 var settings = require('../boot/settings')
 var mailer = require('../boot/mailer').getMailer()
-var passport = require('../boot/passport')
+var authenticator = require('../lib/authenticator')
 var qs = require('qs')
 var InvalidRequestError = require('../errors/InvalidRequestError')
 var providers = require('../providers')
@@ -53,7 +53,7 @@ module.exports = function (server) {
       if (!req.provider) {
         next(new InvalidRequestError('Invalid provider'))
       } else {
-        passport.authenticate(req.body.provider, req, res, next, function (err, user, info) {
+        authenticator.dispatch(req.body.provider, req, res, next, function (err, user, info) {
           if (err) {
             res.render('signin', {
               params: qs.stringify(req.body),
@@ -73,7 +73,7 @@ module.exports = function (server) {
               formError: info.message
             })
           } else {
-            passport.login(req, user)
+            authenticator.login(req, user)
             next()
           }
         })

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -7,7 +7,7 @@
 var oidc = require('../oidc')
 var settings = require('../boot/settings')
 var passwordProvider = require('../providers').password
-var passport = require('../boot/passport')
+var authenticator = require('../lib/authenticator')
 var qs = require('qs')
 var User = require('../models/User')
 var PasswordsDisabledError = require('../errors/PasswordsDisabledError')
@@ -48,11 +48,11 @@ module.exports = function (server) {
           error: err.message
         })
       } else {
-        passport.authenticate('password', req, res, next, function (err, user, info) {
+        authenticator.dispatch('password', req, res, next, function (err, user, info) {
           if (err) { return next(err) }
           if (!user) {
           } else {
-            passport.login(req, user)
+            authenticator.login(req, user)
             req.sendVerificationEmail =
               req.provider.emailVerification.enable
             req.flash('isNewUser', true)

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -7,8 +7,7 @@
 var oidc = require('../oidc')
 var settings = require('../boot/settings')
 var passwordProvider = require('../providers').password
-var crypto = require('crypto')
-var passport = require('passport')
+var passport = require('../boot/passport')
 var qs = require('qs')
 var User = require('../models/User')
 var PasswordsDisabledError = require('../errors/PasswordsDisabledError')
@@ -49,21 +48,17 @@ module.exports = function (server) {
           error: err.message
         })
       } else {
-        passport.authenticate('password', function (err, user, info) {
+        passport.authenticate('password', req, res, next, function (err, user, info) {
           if (err) { return next(err) }
           if (!user) {
           } else {
-            req.login(user, function (err) {
-              if (err) { return next(err) }
-              oidc.setSessionAmr(req.session, req.provider.amr)
-              req.session.opbs = crypto.randomBytes(256).toString('hex')
-              req.sendVerificationEmail =
-                req.provider.emailVerification.enable
-              req.flash('isNewUser', true)
-              next()
-            })
+            passport.login(req, user)
+            req.sendVerificationEmail =
+              req.provider.emailVerification.enable
+            req.flash('isNewUser', true)
+            next()
           }
-        })(req, res, next)
+        })
       }
     })
   }

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@
  */
 
 var express = require('express')
-var passport = require('passport')
 var server = express()
 
 /**
@@ -11,7 +10,7 @@ var server = express()
  */
 
 require('./boot/server')(server)
-require('./boot/passport')(passport)
+require('./boot/passport').registerProviders()
 
 /**
  * Routes

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var server = express()
  */
 
 require('./boot/server')(server)
-require('./boot/passport').registerProviders()
+require('./lib/authenticator').registerProviders()
 
 /**
  * Routes

--- a/test/unit/oidc/authenticateUser.coffee
+++ b/test/unit/oidc/authenticateUser.coffee
@@ -89,7 +89,7 @@ describe 'Authenticate User', ->
 
     before ->
       req =
-        isAuthenticated: sinon.stub().returns(true)
+        user: {}
       res = {}
       next = sinon.spy()
 
@@ -107,8 +107,7 @@ describe 'Authenticate User', ->
   describe 'with unauthenticated session', ->
 
     before ->
-      req =
-        isAuthenticated: sinon.stub().returns(false)
+      req = {}
       res = {}
       next = sinon.spy()
 

--- a/test/unit/oidc/requireSignin.coffee
+++ b/test/unit/oidc/requireSignin.coffee
@@ -22,7 +22,7 @@ describe 'Require Signin', ->
   beforeEach ->
     req = (params, authenticated) ->
       connectParams: params
-      isAuthenticated: -> authenticated
+      user: if authenticated then {} else undefined
       client: {}
       session: {}
     res = redirect: sinon.spy()

--- a/test/unit/oidc/sessionEvents.coffee
+++ b/test/unit/oidc/sessionEvents.coffee
@@ -36,7 +36,7 @@ describe 'Session Events', ->
     sessionEvents(req, res)
 
   it 'should set the socket timeout', ->
-    req.socket.setTimeout.should.have.been.calledWith Infinity
+    req.socket.setTimeout.should.have.been.calledWith 0
 
   it 'should respond 200', ->
 

--- a/test/unit/oidc/signout.coffee
+++ b/test/unit/oidc/signout.coffee
@@ -12,6 +12,7 @@ chai.should()
 
 
 settings = require '../../../boot/settings'
+passport = require '../../../boot/passport'
 Client = require '../../../models/Client'
 IDToken = require '../../../models/IDToken'
 InvalidTokenError = require '../../../errors/InvalidTokenError'
@@ -54,7 +55,6 @@ describe 'Signout', ->
               id_token_hint: validIDToken
             session:
               opbs: opbs
-            logout: sinon.spy()
           res =
             set: sinon.spy()
             send: sinon.spy()
@@ -83,7 +83,6 @@ describe 'Signout', ->
               id_token_hint: validIDToken
             session:
               opbs: opbs
-            logout: sinon.spy()
           res =
             set: sinon.spy()
             send: sinon.spy()
@@ -113,6 +112,7 @@ describe 'Signout', ->
       describe 'and unknown uri', ->
 
         before ->
+          sinon.spy passport, 'logout'
           client = new Client
             post_logout_redirect_uris: []
           sinon.stub(Client, 'get').callsArgWith(1, null, client)
@@ -124,7 +124,6 @@ describe 'Signout', ->
             session:
               opbs: opbs
               amr: ['pwd']
-            logout: sinon.spy()
           res =
             set: sinon.spy()
             sendStatus: sinon.spy()
@@ -133,10 +132,11 @@ describe 'Signout', ->
           signout(req, res, next)
 
         after ->
+          passport.logout.restore()
           Client.get.restore()
 
         it 'should logout', ->
-          req.logout.should.have.been.called
+          passport.logout.should.have.been.called
 
         it 'should update OP browser state', ->
           req.session.opbs.should.not.equal opbs
@@ -151,6 +151,7 @@ describe 'Signout', ->
       describe 'and valid uri', ->
 
         before ->
+          sinon.spy passport, 'logout'
           client = new Client
             post_logout_redirect_uris: ['http://example.com']
           sinon.stub(Client, 'get').callsArgWith(1, null, client)
@@ -162,7 +163,6 @@ describe 'Signout', ->
             session:
               opbs: opbs
               amr: ['otp']
-            logout: sinon.spy()
           res =
             set: sinon.spy()
             send: sinon.spy()
@@ -171,10 +171,11 @@ describe 'Signout', ->
           signout(req, res, next)
 
         after ->
+          passport.logout.restore()
           Client.get.restore()
 
         it 'should logout', ->
-          req.logout.should.have.been.called
+          passport.logout.should.have.been.called
 
         it 'should update OP browser state', ->
           req.session.opbs.should.not.equal opbs
@@ -212,6 +213,7 @@ describe 'Signout', ->
   describe 'with uri only', ->
 
     before ->
+      sinon.spy passport, 'logout'
       opbs = 'b3f0r3'
       req =
         query:
@@ -219,14 +221,16 @@ describe 'Signout', ->
         session:
           opbs: opbs
           amr: ['sms', 'otp']
-        logout: sinon.spy()
       res =
         redirect: sinon.spy()
       next = sinon.spy()
       signout(req, res, next)
 
+    after ->
+      passport.logout.restore()
+
     it 'should logout', ->
-      req.logout.should.have.been.called
+      passport.logout.should.have.been.called
 
     it 'should update OP browser state', ->
       req.session.opbs.should.not.equal opbs
@@ -243,21 +247,24 @@ describe 'Signout', ->
   describe 'without uri', ->
 
     before ->
+      sinon.spy passport, 'logout'
       opbs = 'b3f0r3'
       req =
         query: {}
         session:
           opbs: opbs
           amr: ['pwd']
-        logout: sinon.spy()
       res =
         set: sinon.spy()
         sendStatus: sinon.spy()
       next = sinon.spy()
       signout(req, res, next)
 
+    after ->
+      passport.logout.restore()
+
     it 'should logout', ->
-      req.logout.should.have.been.called
+      passport.logout.should.have.been.called
 
     it 'should update OP browser state', ->
       req.session.opbs.should.not.equal opbs


### PR DESCRIPTION
Logic in the passport library was conflicting in scope with Anvil Connect's own provider handling.

Now, strategies are interfaced with directly, and there is no need to bring in the passport library itself.

This maintains compatibility with existing passport strategies.

Fixes #143