### PR TITLE
Validate that jwks and jwks_uri are not used together

### DIFF
--- a/models/Client.js
+++ b/models/Client.js
@@ -635,6 +635,41 @@ Client.__client = client
 Client.intersects('roles')
 
 /**
+ * Custom validation
+ */
+
+var originalValidate = Client.validate
+Client.validate = function (data) {
+  var validation = originalValidate.apply(this, arguments)
+
+  // http://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+  // "The jwks_uri and jwks parameters MUST NOT be used together."
+  if (data.jwks && data.jwks_uri) {
+    validation = validation || new Modinha.ValidationError({ errors: {} })
+
+    validation.errors.jwks = {
+      property: 'jwks',
+      expected: false,
+      actual: data.jwks,
+      message: 'Cannot use jwks at the same time as jwks_uri'
+    }
+
+    validation.errors.jwks_uri = {
+      property: 'jwks_uri',
+      expected: false,
+      actual: data.jwks_uri,
+      message: 'Cannot use jwks_uri at the same time as jwks'
+    }
+  }
+
+  return validation
+}
+
+Client.prototype.validate = function () {
+  return Client.validate(this)
+}
+
+/**
  * Authorized scope
  */
 

--- a/test/unit/models/clientSpec.coffee
+++ b/test/unit/models/clientSpec.coffee
@@ -265,6 +265,43 @@ describe 'Client', ->
 
 
 
+  describe 'validation', ->
+
+    {withJWKs,withJWKsURI,withJWKsAndJWKsURI} = {}
+
+    describe 'with either jwks or jwks_uri set', ->
+
+      before ->
+        withJWKs = Client.initialize(
+          jwks: '1234567890'
+        ).validate()
+        withJWKsURI = Client.initialize(
+          jwks_uri: 'http://example.com/jwks'
+        ).validate()
+
+      it 'should not provide an error for jwks', ->
+        expect(withJWKs.errors.jwks).to.be.undefined
+
+      it 'should not provide an error for jwks_uri', ->
+        expect(withJWKs.errors.jwks_uri).to.be.undefined
+
+    describe 'with both jwks and jwks_uri set', ->
+
+      before ->
+        withJWKsAndJWKsURI = Client.initialize(
+          jwks: '1234567890'
+          jwks_uri: 'http://example.com/jwks'
+        ).validate()
+
+      it 'should provide an error for jwks', ->
+        expect(withJWKsAndJWKsURI.errors.jwks).to.be.an 'object'
+
+      it 'should provide an error for jwks_uri', ->
+        expect(withJWKsAndJWKsURI.errors.jwks_uri).to.be.an 'object'
+
+
+
+
   describe 'configuration', ->
 
     {client,configuration,token} = {}


### PR DESCRIPTION
Fixes #98 

This involved customizing the validation function for the `Client` model because there is no logic in [Modinha](https://github.com/anvilresearch/modinha) or [Revalidator](https://github.com/flatiron/revalidator) that supports cross-property validation rules.

cc @christiansmith 