### PR TITLE
Fix handling of optional `options` parameter in Passport shim

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -76,7 +76,7 @@ function dispatch (provider, req, res, next, options, callback) {
     ))
   }
 
-  if (!callback) {
+  if (!callback && typeof options === 'function') {
     callback = options
     options = undefined
   }


### PR DESCRIPTION
Prior, if no callback was given, the logic would assume that `options` was the callback. Now, it checks to make sure that `options` is a function first before making that same assumption.