### PR TITLE
Create first time setup endpoint

### DIFF
--- a/boot/server.js
+++ b/boot/server.js
@@ -5,6 +5,7 @@
 var cwd = process.cwd()
 var path = require('path')
 var settings = require('./settings')
+var setup = require('./setup')
 var client = require('./redis').getClient()
 var logger = require('./logger')(settings.logger)
 require('./mailer').getMailer()
@@ -19,6 +20,20 @@ var RedisStore = require('connect-redis')(session)
 var connectFlash = require('connect-flash')
 var cors = require('cors')
 var sessionStore = new RedisStore({ client: client })
+
+/**
+ * Read setup token if the server is in out-of-box mode
+ */
+
+setup.isOOB(function (err, oob) {
+  if (err) { return console.log(err) }
+  if (oob) {
+    setup.readSetupToken(function (err, token) {
+      if (err) { return console.log(err) }
+      settings.setupToken = token
+    })
+  }
+})
 
 /**
  * Exports

--- a/boot/settings.js
+++ b/boot/settings.js
@@ -447,6 +447,23 @@ if (!settings.issuer) {
 }
 
 /**
+ * Always enable password provider
+ *
+ * Authority users always need to be able to sign in to administer the server
+ */
+
+if (!settings.providers.password) {
+  settings.providers.password = {
+    hidden: true,
+    allowRoles: [ 'authority' ]
+  }
+} else if (settings.providers.password.allowRoles) {
+  if (settings.providers.password.allowRoles.indexOf('authority') === -1) {
+    settings.providers.password.allowRoles.push('authority')
+  }
+}
+
+/**
  * Config-file dependenct settings
  */
 

--- a/boot/setup.js
+++ b/boot/setup.js
@@ -1,0 +1,60 @@
+/* global process */
+
+/**
+ * Module dependencies
+ */
+
+var User = require('../models/User')
+var crypto = require('crypto')
+var fs = require('fs')
+var path = require('path')
+var cwd = process.cwd()
+var setupTokenPath = path.join(cwd, 'keys', 'setup.token')
+
+/**
+ * Check if server is in out-of-box mode
+ */
+
+function isOOB (cb) {
+  User.listByRoles('authority', function (err, users) {
+    if (err) { return cb(err) }
+    // return true if there are no authority users
+    return cb(null, !users || !users.length)
+  })
+}
+exports.isOOB = isOOB
+
+/**
+ * Read setup token from filesystem or create if missing
+ */
+
+function readSetupToken (cb) {
+  var token
+  var write = false
+
+  try {
+    // try to read setup token from filesystem
+    token = fs.readFileSync(setupTokenPath).toString()
+    // if token is blank, try to generate a new token and save it
+    if (!token.trim()) {
+      write = true
+    }
+  } catch (err) {
+    // if unable to read, try to generate a new token and save it
+    write = true
+  }
+
+  if (write) {
+    token = crypto.randomBytes(256).toString('hex')
+    try {
+      fs.writeFileSync(setupTokenPath, token)
+    } catch (err) {
+      // if we can't write the token to disk, something is very wrong
+      return cb(err)
+    }
+  }
+
+  // return the token
+  cb(null, token)
+}
+exports.readSetupToken = readSetupToken

--- a/protocols/Password.js
+++ b/protocols/Password.js
@@ -4,21 +4,43 @@
 
 var LocalStrategy = require('passport-local').Strategy
 var User = require('../models/User')
+var Role = require('../models/Role')
 
 /**
  * Verifier
  */
 
-function verifier (req, email, password, done) {
-  User.authenticate(email, password, function (err, user, info) {
-    if (user) {
-      // throw password value away so isn't included in URLs/logged
-      delete req.connectParams.password
-      delete req.connectParams.email
-    }
+function verifier (configuration) {
+  return function (req, email, password, done) {
+    User.authenticate(email, password, function (err, user, info) {
+      if (err) { return done(err, null, info) }
+      if (user) {
+        // throw password value away so isn't included in URLs/logged
+        delete req.connectParams.password
+        delete req.connectParams.email
+      }
 
-    done(err, user, info)
-  })
+      if (!configuration.allowRoles) {
+        return done(null, user, info)
+      } else if (!user) {
+        return done(null, false, { message: 'Unknown user.' })
+      } else {
+        Role.listByUsers(user, function (err, roles) {
+          if (err) { return done(err) }
+
+          var hasRoles = roles && roles.some(function (role) {
+            return configuration.allowRoles.indexOf(role.name) !== -1
+          })
+
+          if (hasRoles) {
+            return done(null, user, info)
+          } else {
+            return done(null, false, { message: 'Unknown user.' })
+          }
+        })
+      }
+    })
+  }
 }
 
 LocalStrategy.verifier = verifier
@@ -28,7 +50,7 @@ LocalStrategy.verifier = verifier
  */
 
 function initialize (provider, configuration) {
-  return new LocalStrategy(provider, verifier)
+  return new LocalStrategy(provider, verifier(configuration))
 }
 
 LocalStrategy.initialize = initialize

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1,0 +1,67 @@
+/**
+ * Module dependencies
+ */
+
+var settings = require('../boot/settings')
+var setup = require('../boot/setup')
+var Client = require('../models/Client')
+var User = require('../models/User')
+var NotFoundError = require('../errors/NotFoundError')
+var InvalidRequestError = require('../errors/InvalidRequestError')
+
+/**
+ * Setup Endpoint
+ */
+
+module.exports = function (server) {
+  server.post('/setup', [
+    function (req, res, next) {
+      setup.isOOB(function (err, oob) {
+        if (err) { return next(err) }
+
+        // Only continue if the server is in out-of-box mode
+        if (oob) {
+          return next()
+        } else {
+          return next(new NotFoundError())
+        }
+      })
+    },
+    function (req, res, next) {
+      // 1. Get token from file
+      var token = settings.setupToken
+      // 2. Check that token matches token in POST body
+      if (req.body.token !== token) {
+        return next(new NotFoundError())
+      }
+      // 3. Create user with given details/credentials
+      if (!req.body.email || !req.body.password) {
+        return next(new InvalidRequestError('Missing credentials'))
+      }
+      User.insert(req.body, function (err, user) {
+        if (err) { return next(err) }
+
+        // 4. Assign user administrator/authority role
+        User.addRoles(user, 'authority', function (err, result) {
+          if (err) { return next(err) }
+
+          // 5. Register client
+          Client.insert({
+            client_name: 'Anvil Connect CLI',
+            redirect_uris: [ settings.issuer ],
+            trusted: 'true'
+          }, function (err, client) {
+            if (err) { return next(err) }
+
+            // 6. Return with client and user details
+            res.send({
+              user: user.project('userinfo'),
+              client: client.project('registration')
+            })
+          })
+        })
+      })
+    }
+  ])
+
+}

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -54,7 +54,7 @@ module.exports = function (server) {
             if (err) { return next(err) }
 
             // 6. Return with client and user details
-            res.send({
+            res.status(201).send({
               user: user.project('userinfo'),
               client: client.project('registration')
             })

--- a/routes/signin.js
+++ b/routes/signin.js
@@ -15,6 +15,13 @@ var providerNames = Object.keys(providers)
 for (var i = 0; i < providerNames.length; i++) {
   providerInfo[providerNames[i]] = providers[providerNames[i]]
 }
+var visibleProviders = {}
+// Only render providers that are not marked as hidden
+Object.keys(settings.providers).forEach(function (providerID) {
+  if (!settings.providers[providerID].hidden) {
+    visibleProviders[providerID] = settings.providers[providerID]
+  }
+})
 
 /**
  * Signin Endpoint
@@ -33,7 +40,7 @@ module.exports = function (server) {
       res.render('signin', {
         params: qs.stringify(req.query),
         request: req.query,
-        providers: settings.providers,
+        providers: visibleProviders,
         providerInfo: providerInfo,
         mailSupport: !!(mailer.transport)
       })
@@ -58,7 +65,7 @@ module.exports = function (server) {
             res.render('signin', {
               params: qs.stringify(req.body),
               request: req.body,
-              providers: settings.providers,
+              providers: visibleProviders,
               providerInfo: providerInfo,
               mailSupport: !!(mailer.transport),
               error: err.message
@@ -67,7 +74,7 @@ module.exports = function (server) {
             res.render('signin', {
               params: qs.stringify(req.body),
               request: req.body,
-              providers: settings.providers,
+              providers: visibleProviders,
               providerInfo: providerInfo,
               mailSupport: !!(mailer.transport),
               formError: info.message

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ require('./lib/authenticator').registerProviders()
  * Routes
  */
 
+require('./routes/setup')(server)
 require('./routes/status')(server)
 require('./routes/discover')(server)
 require('./routes/register')(server)

--- a/test/unit/boot/setup.coffee
+++ b/test/unit/boot/setup.coffee
@@ -1,0 +1,185 @@
+# Test dependencies
+cwd         = process.cwd()
+fs          = require 'fs'
+path        = require 'path'
+chai        = require 'chai'
+sinon       = require 'sinon'
+sinonChai   = require 'sinon-chai'
+expect      = chai.expect
+
+
+
+
+# Configure Chai and Sinon
+chai.use sinonChai
+chai.should()
+
+
+
+
+# Code under test
+setup       = require path.join(cwd, 'boot/setup')
+User        = require path.join(cwd, 'models/User')
+
+
+
+
+describe 'Setup', ->
+
+  describe 'out-of-box detector', ->
+
+    describe 'with no authority users', ->
+
+      {err,result} = {}
+
+      before (done) ->
+        sinon.stub(User, 'list').callsArgWith(1, null, [])
+        setup.isOOB (error, isOOB) ->
+          err = error
+          result = isOOB
+          done()
+
+      after ->
+        User.list.restore()
+
+      it 'should not provide an error', ->
+        expect(err).to.not.be.ok
+
+      it 'should provide true', ->
+        expect(result).to.equal true
+
+
+    describe 'with an authority user', ->
+
+      {err,result} = {}
+
+      before (done) ->
+        sinon.stub(User, 'list').callsArgWith(1, null, [
+          User.initialize()
+        ])
+        setup.isOOB (error, isOOB) ->
+          err = error
+          result = isOOB
+          done()
+
+      after ->
+        User.list.restore()
+
+      it 'should not provide an error', ->
+        expect(err).to.not.be.ok
+
+      it 'should provide false', ->
+        expect(result).to.equal false
+
+  describe 'token reader/writer', ->
+
+    describe 'with existing token file', ->
+
+      {err,token} = {}
+
+      before (done) ->
+        sinon.stub fs, 'readFileSync', ->
+          toString: ->
+            '0123456789abcdef'
+        sinon.stub fs, 'writeFileSync'
+
+        setup.readSetupToken (error, setupToken) ->
+          err = error
+          token = setupToken
+          done()
+
+      after ->
+        fs.readFileSync.restore()
+        fs.writeFileSync.restore()
+
+      it 'should not provide an error', ->
+        expect(err).to.not.be.ok
+
+      it 'should provide the token in the file', ->
+        expect(token).to.equal '0123456789abcdef'
+
+      it 'should not write to the token file', ->
+        fs.writeFileSync.should.not.have.been.called
+
+    describe 'with no token file', ->
+
+      {err,token} = {}
+
+      before (done) ->
+        sinon.stub fs, 'readFileSync', ->
+          throw new Error()
+        sinon.stub fs, 'writeFileSync'
+
+        setup.readSetupToken (error, setupToken) ->
+          err = error
+          token = setupToken
+          done()
+
+      after ->
+        fs.readFileSync.restore()
+        fs.writeFileSync.restore()
+
+      it 'should not provide an error', ->
+        expect(err).to.not.be.ok
+
+      it 'should provide a new token', ->
+        expect(token).to.be.a 'string'
+
+      it 'should create a token file', ->
+        fs.writeFileSync.should.have.been.called
+
+    describe 'with blank token file', ->
+
+      {err,token} = {}
+
+      before (done) ->
+        sinon.stub fs, 'readFileSync', ->
+          toString: ->
+            ''
+        sinon.stub fs, 'writeFileSync'
+
+        setup.readSetupToken (error, setupToken) ->
+          err = error
+          token = setupToken
+          done()
+
+      after ->
+        fs.readFileSync.restore()
+        fs.writeFileSync.restore()
+
+      it 'should not provide an error', ->
+        expect(err).to.not.be.ok
+
+      it 'should provide a new token', ->
+        expect(token).to.be.a 'string'
+
+      it 'should create a token file', ->
+        fs.writeFileSync.should.have.been.called
+
+    describe 'with whitespace-filled token file', ->
+
+      {err,token} = {}
+
+      before (done) ->
+        sinon.stub fs, 'readFileSync', ->
+          toString: ->
+            '        '
+        sinon.stub fs, 'writeFileSync'
+
+        setup.readSetupToken (error, setupToken) ->
+          err = error
+          token = setupToken
+          done()
+
+      after ->
+        fs.readFileSync.restore()
+        fs.writeFileSync.restore()
+
+      it 'should not provide an error', ->
+        expect(err).to.not.be.ok
+
+      it 'should provide a new token', ->
+        expect(token).to.be.a 'string'
+
+      it 'should create a token file', ->
+        fs.writeFileSync.should.have.been.called

--- a/test/unit/oidc/requireVerifiedEmail.coffee
+++ b/test/unit/oidc/requireVerifiedEmail.coffee
@@ -13,6 +13,7 @@ chai.should()
 
 
 {requireVerifiedEmail} = require '../../../oidc'
+Role = require '../../../models/Role'
 
 
 
@@ -23,7 +24,7 @@ describe 'Require verified email', ->
 
   describe 'with email already verified', ->
 
-    before ->
+    before (done) ->
       req =
         user:
           emailVerified: true
@@ -31,14 +32,60 @@ describe 'Require verified email', ->
           emailVerification:
             enable: true
             require: true
+      sinon.stub(Role, 'listByUsers').callsArgWith 1, null, []
 
-      res = { render: sinon.spy() }
-      next = sinon.spy()
+      res =
+        render: sinon.spy ->
+          done()
+
+      next = sinon.spy ->
+        done()
 
       options =
         force: true
 
       requireVerifiedEmail(options) req, res, next
+
+    after ->
+      Role.listByUsers.restore()
+
+    it 'should not prompt the user for verification', ->
+      res.render.should.not.have.been.called
+
+    it 'should continue', ->
+      next.should.have.been.called
+
+
+
+
+  describe 'with authority user', ->
+
+    before (done) ->
+      req =
+        user:
+          emailVerified: false
+        provider:
+          emailVerification:
+            enable: true
+            require: true
+      sinon.stub(Role, 'listByUsers').callsArgWith 1, null, [{
+        name: 'authority'
+      }]
+
+      res =
+        render: sinon.spy ->
+          done()
+
+      next = sinon.spy ->
+        done()
+
+      options =
+        force: true
+
+      requireVerifiedEmail(options) req, res, next
+
+    after ->
+      Role.listByUsers.restore()
 
     it 'should not prompt the user for verification', ->
       res.render.should.not.have.been.called
@@ -51,7 +98,7 @@ describe 'Require verified email', ->
 
   describe 'with unverified email and verification required', ->
 
-    before ->
+    before (done) ->
       req =
         user:
           emailVerified: false
@@ -60,14 +107,22 @@ describe 'Require verified email', ->
             enable: true
             require: true
         flash: sinon.spy (key) -> [true]
+      sinon.stub(Role, 'listByUsers').callsArgWith 1, null, []
 
-      res = { render: sinon.spy() }
-      next = sinon.spy()
+      res =
+        render: sinon.spy ->
+          done()
+
+      next = sinon.spy ->
+        done()
 
       options =
         force: true
 
       requireVerifiedEmail(options) req, res, next
+
+    after ->
+      Role.listByUsers.restore()
 
     it 'should prompt the user for verification', ->
       res.render.should.have.been.called
@@ -91,7 +146,7 @@ describe 'Require verified email', ->
 
   describe 'with unverified email, verification required, and custom view', ->
 
-    before ->
+    before (done) ->
       req =
         user:
           emailVerified: false
@@ -100,9 +155,14 @@ describe 'Require verified email', ->
             enable: true
             require: true
         flash: sinon.spy (key) -> [true]
+      sinon.stub(Role, 'listByUsers').callsArgWith 1, null, []
 
-      res = { render: sinon.spy() }
-      next = sinon.spy()
+      res =
+        render: sinon.spy ->
+          done()
+
+      next = sinon.spy ->
+        done()
 
       options =
         view: 'testView'
@@ -111,6 +171,9 @@ describe 'Require verified email', ->
         force: true
 
       requireVerifiedEmail(options) req, res, next
+
+    after ->
+      Role.listByUsers.restore()
 
     it 'should prompt the user for verification', ->
       res.render.should.have.been.called
@@ -129,7 +192,7 @@ describe 'Require verified email', ->
 
   describe 'with unverified email and email verification disabled', ->
 
-    before ->
+    before (done) ->
       req =
         user:
           emailVerified: false
@@ -137,14 +200,22 @@ describe 'Require verified email', ->
           emailVerification:
             enable: false
             require: true
+      sinon.stub(Role, 'listByUsers').callsArgWith 1, null, []
 
-      res = { render: sinon.spy() }
-      next = sinon.spy()
+      res =
+        render: sinon.spy ->
+          done()
+
+      next = sinon.spy ->
+        done()
 
       options =
         force: true
 
       requireVerifiedEmail(options) req, res, next
+
+    after ->
+      Role.listByUsers.restore()
 
     it 'should not prompt the user for verification', ->
       res.render.should.not.have.been.called
@@ -157,7 +228,7 @@ describe 'Require verified email', ->
 
   describe 'with unverified email, verification enabled, forced, not required', ->
 
-    before ->
+    before (done) ->
       req =
         user:
           emailVerified: false
@@ -166,14 +237,22 @@ describe 'Require verified email', ->
             enable: true
             require: false
         flash: sinon.spy (key) -> [true]
+      sinon.stub(Role, 'listByUsers').callsArgWith 1, null, []
 
-      res = { render: sinon.spy() }
-      next = sinon.spy()
+      res =
+        render: sinon.spy ->
+          done()
+
+      next = sinon.spy ->
+        done()
 
       options =
         force: true
 
       requireVerifiedEmail(options) req, res, next
+
+    after ->
+      Role.listByUsers.restore()
 
     it 'should prompt the user for verification', ->
       res.render.should.have.been.called


### PR DESCRIPTION
## New features
- If no users with the `authority` role exist in the database, the server allows the use of a setup REST endpoint to create the first authority user and register the CLI client. A token, saved to the keys directory, is required to prevent the endpoint from being used by an opportunist
- All providers now support a `hidden` boolean property which hides the provider off the sign-in screen
- The password provider can be limited to only authenticate users with a certain role using the `allowRoles` array property on the provider configuration