### PR TITLE
Link to getting started guide in connect-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,78 +36,9 @@
 
 
 
-## Get Started
+## Getting Started
 
-#### Requirements
-
-The CLI tools require recent versions of [Node.js](https://nodejs.org/) (or
-[io.js](https://iojs.org/en/index.html)) and npm. If you plan to run your
-server with [Docker](https://www.docker.com/), you'll need Docker and Docker
-Compose installed (we provide Dockerfiles and docker-compose.yml). On Mac OS X
-you'll also need [boot2docker](http://boot2docker.io/). If you wish to run the
-server without Docker, you'll need access to a local or remotely accessible
-[Redis](http://redis.io/) instance. Python, C/C++ compiler are needed on your
-system for building native Nodejs packages, and OpenSSL is required to create
-key pairs and certificates. In production, you'll also need a reverse proxy/
-load balancer that handles SSL termination. We recommend [nginx](http://nginx.org/).
-
-#### Install the CLI tools
-
-```bash
-$ npm install -g anvil-connect anvil-connect-cli
-```
-
-
-#### Generate your deployment repository
-
-```bash
-# Make a place for your project to live
-$ mkdir path/to/project
-$ cd path/to/project
-
-# Generate a deployment repository
-$ nvl init
-? What would you like to name your Connect instance? myauthserver
-? What (sub)domain will you use? connect.example.com
-? Would you like to use Docker? Yes
-? Would you like to run Redis? Yes
-? Would you like to run nginx? Yes
-? Would you like to create a self-signed SSL cert? Yes
-? Country Name (2 letter code) US
-? State or Province Name (full name) South Dakota
-? Locality Name (eg, city) Rapid City
-? Organization Name (eg, company) Anvil Research, Inc.
-```
-
-#### Running with Docker
-
-Run docker-compose from the root of your new project.
-
-```bash
-$ docker-compose up -d
-```
-
-#### Running without Docker
-
-The first time, you'll need to install npm and bower dependencies.
-
-```bash
-$ cd connect
-$ npm install && bower install
-```
-
-Then you can start the server in with `node` or `npm`.
-
-```bash
-# development mode
-$ node server.js
-
-# production mode
-$ NODE_ENV=production node server.js
-```
-
-## Documentation
-
+* **[Getting started guide](https://github.com/anvilresearch/connect-docs/tree/master/getting-started.md)**
 * [Documentation](https://github.com/anvilresearch/connect-docs)
 * [References](https://github.com/anvilresearch/connect/wiki/References)
 


### PR DESCRIPTION
Maintaining all different copies of the getting started guide is becoming an unnecessary burden.