### PR TITLE
Added coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ public/vendor
 npm-debug.log
 .settings
 .vscode
+coverage

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "start": "node server.js",
     "test": "eslint --ignore-path .gitignore . && echo Code looks good! && mocha test/unit",
     "lint": "eslint --ignore-path .gitignore . && echo Code looks good!",
+    "test-cov": "istanbul cover --config test/istanbul.yml node_modules/mocha/bin/_mocha -- --require coffee-coverage/register-istanbul test/unit",
     "test-watch": "mocha test/unit --watch",
     "test-integration": "mocha test/integration",
     "test-integration-watch": "mocha test/integration --watch",
@@ -90,7 +91,9 @@
     "nock": "^2.2.0",
     "sinon": "^1.15.1",
     "sinon-chai": "^2.8.0",
-    "supertest": "^1.0.1"
+    "supertest": "^1.0.1",
+    "istanbul": "^0.3.5",
+    "coffee-coverage": "^0.6.3"
   },
   "dependencies": {
     "anvil-connect-jwt": "^0.1.5",

--- a/test/istanbul.yml
+++ b/test/istanbul.yml
@@ -1,0 +1,49 @@
+verbose: false
+instrumentation:
+    root: lib
+    default-excludes: true
+    excludes: []
+    embed-source: false
+    variable: __coverage__
+    compact: true
+    preserve-comments: false
+    complete-copy: false
+    save-baseline: false
+    baseline-file: ./coverage/coverage-baseline.json
+    include-all-sources: true
+reporting:
+    print: summary
+    reports:
+        - lcov
+    dir: ./coverage
+    watermarks:
+        statements: [50, 80]
+        lines: [50, 80]
+        functions: [50, 80]
+        branches: [50, 80]
+    report-config:
+        clover: {file: clover.xml}
+        cobertura: {file: cobertura-coverage.xml}
+        json: {file: coverage-final.json}
+        json-summary: {file: coverage-summary.json}
+        lcovonly: {file: lcov.info}
+        teamcity: {file: null}
+        text: {file: null, maxCols: 0}
+        text-summary: {file: null}
+hooks:
+    hook-run-in-context: false
+    post-require-hook: null
+    handle-sigint: false
+check:
+    global:
+        statements: 0
+        lines: 0
+        branches: 0
+        functions: 0
+        excludes: []
+    each:
+        statements: 0
+        lines: 0
+        branches: 0
+        functions: 0
+        excludes: []


### PR DESCRIPTION
```npm run test-cov``` will run unit tests and generate reports using [istanbul](https://github.com/gotwarlost/istanbul)

Runs against unit tests

If this is agreeable, I can generate a PR for connect-cli after we merge this one.