### PR TITLE
Make from field validation regex more flexible

### DIFF
--- a/boot/mailer.js
+++ b/boot/mailer.js
@@ -73,7 +73,7 @@ exports.getMailer = function () {
   if (mailer) {
     return mailer
   } else {
-    var fromVerifier = /^(?:\w|\s)+<[a-z]+@[a-z]+\.[a-z]{2,}>$/igm
+    var fromVerifier = /^(?:\w|\s)+<[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}>$/igm
     var transport = settings.mailer &&
       nodemailer.createTransport(settings.mailer)
 


### PR DESCRIPTION
Prior, it wouldn't accept `no-reply@example.com` because of the hyphen in `no-reply`. Now, assuming all is well, it should be able to accept any valid e-mail address, provided that e-mail address is encoded out to safe ASCII characters.