### PR TITLE
exp / expires_in should be set to offset

### DIFF
--- a/oidc/token.js
+++ b/oidc/token.js
@@ -87,7 +87,7 @@ function token (req, res, next) {
       iss: settings.issuer,
       sub: req.client._id,
       aud: req.client._id,
-      exp: req.client.default_max_age,
+      exp: (req.client.default_max_age ? nowSeconds(req.client.default_max_age) : undefined),
       scope: req.scope
     }, privateKey, function (err, token) {
       if (err) { return next(err) }
@@ -103,7 +103,7 @@ function token (req, res, next) {
       }
 
       if (req.client.default_max_age) {
-        response.expires_in = req.client.default_max_age
+        response.expires_in = nowSeconds(req.client.default_max_age)
       }
 
       res.json(response)


### PR DESCRIPTION
when client.default_max_age is present it should be used as an offset not as a value