### PR TITLE
Repair broken `this` reference in authorizedScope()

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -149,13 +149,14 @@ User.intersects('roles')
 
 User.prototype.authorizedScope = function (callback) {
   var client = User.__client
+  var self = this
 
   // get a list of unrestricted scope names
   client.zrange('scopes:restricted:false', 0, -1, function (err, unrestricted) {
     if (err) { return callback(err) }
 
     // get a list of roles for this user
-    client.zrange('users:' + this._id + ':roles', 0, -1, function (err, roles) {
+    client.zrange('users:' + self._id + ':roles', 0, -1, function (err, roles) {
       if (err) { return callback(err) }
 
       if (!roles || roles.length === 0) {


### PR DESCRIPTION
A recent commit changed `User.prototype.authorizedScope` to look up unrestricted scopes from the data store. This change wrapped a `this._id` in a new function, causing the references to that property to be undefined. This caused user role lookups to always result in an empty array, and therefore authorization requests including restricted scopes would issue tokens omitting those scopes. This PR fixes the problem.