### PR TITLE
Remove `nv` binary reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,9 +70,6 @@
     "test-all": "mocha test/unit && mocha test/integration",
     "coverage": "./coverage.sh"
   },
-  "bin": {
-    "nv": "./bin/nv"
-  },
   "main": "server.js",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
PR #268 removes most of the references to the old CLI, but it was still referenced from `package.json`. This removes that reference.