### PR TITLE
Improve coveralls in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,8 @@ install:
   - npm install
 
 script:
-  - NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - NODE_ENV=test npm run coverage
   - NODE_ENV=test npm run lint
+
+after_script:
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![IRC](https://img.shields.io/badge/Slack-IRC-green.svg)](https://anvilresearch.slack.com/account/gateways)
 
 [![Build Status](https://travis-ci.org/anvilresearch/connect.svg?branch=master)](https://travis-ci.org/anvilresearch/connect)
+[![Coverage Status](https://coveralls.io/repos/anvilresearch/connect/badge.svg?branch=master&service=github)](https://coveralls.io/github/anvilresearch/connect?branch=master)
 ![Dependencies](https://img.shields.io/david/anvilresearch/connect.svg) ![License](https://img.shields.io/github/license/anvilresearch/connect.svg) ![Downloads](https://img.shields.io/npm/dm/anvil-connect.svg)
 ![npm](https://img.shields.io/npm/v/anvil-connect.svg)
 
@@ -77,4 +78,3 @@ Support and consulting also available, contact us via [the website](http://anvil
 ## MIT License
 
 Copyright (c) 2015 [Anvil Research, Inc.](http://anvil.io)
-

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# This script was used by package.json during `npm run coverage`
+#
+# Initially this was done to have our unit tests and integration
+# tests run seperately while still combining their coverage data.
+#
+# One reason to was that the tests were failing when run together.
+# Now something has changed and this is no longer the case.
+#
+# Since we want to be able to run all tests at once it makes
+# sense to do this during the build so regressions will fail the
+# build.
+#
+# This script remains useful during development.
 
 set -e
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test-integration": "mocha test/integration",
     "test-integration-watch": "mocha test/integration --watch",
     "test-all": "mocha test/unit && mocha test/integration",
-    "coverage": "./coverage.sh"
+    "coverage": "NODE_ENV=test istanbul cover _mocha -- test/"
   },
   "main": "server.js",
   "license": "MIT",


### PR DESCRIPTION
Add coveralls badge and improve build script.

**Update original comment!**

The introduction of the coveralls build somewhat unintentionally
had all tests running at once. This used to fail which was the reason
that the coverage.sh script was introduced so that the coverage would
run separately for unit and integration tests and the results were combined.

However it should really be possible to run all tests at once, so that
it makes sense to do so in the build. This should allow to see regressions
in this respect.

The coverage script itself is kept as it can still be useful during
development if only to see how one can run the commands in a shell without
installing istanbul or mocha globally.

Finally the travis script now sends coverage data in a second step to
coveralls with the intent to easier distinguish cases where the tests fail and
where coveralls fails.
