### PR TITLE
Specifying 'query' response_mode still resulted in fragmented (#) response.

### DIFF
--- a/views/signin.jade
+++ b/views/signin.jade
@@ -19,6 +19,8 @@ html(lang="en")
             | Try one of these:
         else if error
           p.error= error
+        if request.response_mode
+          input(type='hidden', name='response_mode', value=request.response_mode)
         input(type='hidden', name='response_type', value=request.response_type)
         input(type='hidden', name='client_id', value=request.client_id)
         input(type='hidden', name='redirect_uri', value=request.redirect_uri)


### PR DESCRIPTION
The signin form was missing a hidden field for the response_mode parameter. Added it to allow caller to specify a response mode. 

Also, made the addition conditional to match the SPEC which indicates to only include the parameter if it varies from the default. If the response_mode is not supplied to the signin form, it is not added to the authorization details.