### PR TITLE
Add missing secret options to example configuration

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -1,6 +1,7 @@
 {
   "issuer": "https://your.authorization.server",
   "client_registration": "dynamic",
+  "cookie_secret": "<INSERT_RANDOM_BYTES>",
   "providers": {
     "google": {
       "client_id": "<CLIENT_ID>",
@@ -14,5 +15,6 @@
   "redis": {
     "url": "redis://HOST:PORT",
     "auth": "PASSWORD"
-  }
+  },
+  "session_secret": "<INSERT_RANDOM_BYTES"
 }


### PR DESCRIPTION
While setting up a new instance I noticed some configuration options were missing in the example configuration related to the secrets used by `express-session`. Anvil Connect will not work properly without these.