### PR TITLE
Ensure writable `logs` folder on boot

### DIFF
--- a/boot/logger.js
+++ b/boot/logger.js
@@ -4,6 +4,7 @@
 
 var cwd = process.cwd()
 var env = process.env.NODE_ENV || 'development'
+var fs = require('fs')
 var path = require('path')
 var bunyan = require('express-bunyan-logger')
 
@@ -14,8 +15,31 @@ var bunyan = require('express-bunyan-logger')
 var streams = []
 
 if (!env.match(/test/i)) {
+  var logs_path = path.join(cwd, 'logs')
+
+  fs.stat(logs_path, function (err, logs_path_stats) {
+    if (err && err.code === 'ENOENT') {
+      fs.mkdir(logs_path, function (err) {
+        if (err) {
+          console.error('Could not create the logs path [%s]', logs_path)
+          process.exit(1)
+        }
+      })
+    } else if (!logs_path_stats.isDirectory()) {
+      console.error('The logs path [%s] is not a directory', logs_path)
+      process.exit(1)
+    }
+
+    fs.access(logs_path, fs.W_OK, function (err) {
+      if (err && err.code === 'EACCES') {
+        console.error('The logs path [%s] is not writable', logs_path)
+        process.exit(1)
+      }
+    })
+  })
+
   streams.push({ stream: process.stdout })
-  streams.push({ path: path.join(cwd, 'logs', env + '.log') })
+  streams.push({ path: path.join(logs_path, env + '.log') })
 }
 
 /**


### PR DESCRIPTION
If the `logs` folder is not available the server will boot up fine, but crash as soon as a log entry is made.I think it's probably better to crash as soon as possible.

I did use the asynchronous versions of `stat` and `access` here, which may cause server boot to be aborted while it's doing other things. I'm not exactly sure if this could actually happen though nor that if it did whether that'd be harmful.

Any input on that is welcome. I can always switch the logic out of the synchronous versions. I don't think keeping the asynchronous version and only setting up the export when the `logs` folder has been verified would work.

Another solution of course would be to add the `logs` folder to the repository itself, but I'm leaning toward creating it if necessary to keep the repository clear of 'empty' folders.