### PR TITLE
Return array of strings from `authorizedScope`

### DIFF
--- a/models/Client.js
+++ b/models/Client.js
@@ -792,7 +792,7 @@ Client.prototype.authorizedScope = function (callback) {
     multi.exec(function (err, results) {
       if (err) { return callback(err) }
       callback(null, results.map(function (result) {
-        return result[1]
+        return result[1][0]
       }))
     })
   })


### PR DESCRIPTION
The `authorizedScope` method should return an array of strings. Before
this fix it would return an array of arrays of strings. This would cause
scopes assigned to clients through roles to not be properly picked up.