### PR TITLE
Extract `ensureWritableDirectory` to `fs-utils`

### DIFF
--- a/boot/logger.js
+++ b/boot/logger.js
@@ -4,9 +4,9 @@
 
 var cwd = process.cwd()
 var env = process.env.NODE_ENV || 'development'
-var fs = require('fs')
 var path = require('path')
 var bunyan = require('express-bunyan-logger')
+var ensureWritableDirectory = require('../lib/fs-utils').ensureWritableDirectory
 
 /**
  * Logstreams
@@ -16,27 +16,7 @@ var streams = []
 
 if (!env.match(/test/i)) {
   var logs_path = path.join(cwd, 'logs')
-
-  fs.stat(logs_path, function (err, logs_path_stats) {
-    if (err && err.code === 'ENOENT') {
-      fs.mkdir(logs_path, function (err) {
-        if (err) {
-          console.error('Could not create the logs path [%s]', logs_path)
-          process.exit(1)
-        }
-      })
-    } else if (!logs_path_stats.isDirectory()) {
-      console.error('The logs path [%s] is not a directory', logs_path)
-      process.exit(1)
-    }
-
-    fs.access(logs_path, fs.W_OK, function (err) {
-      if (err && err.code === 'EACCES') {
-        console.error('The logs path [%s] is not writable', logs_path)
-        process.exit(1)
-      }
-    })
-  })
+  ensureWritableDirectory(logs_path)
 
   streams.push({ stream: process.stdout })
   streams.push({ path: path.join(logs_path, env + '.log') })

--- a/lib/fs-utils.js
+++ b/lib/fs-utils.js
@@ -1,0 +1,30 @@
+var fs = require('fs')
+
+/**
+ * Makes sure the requested directory exists and is writable
+ * @param {string} path string specifying the path to the directory that should exist and be writable
+ * @return {void}
+ * @api private
+ */
+exports.ensureWritableDirectory = function (path) {
+  fs.stat(path, function (err, path_stats) {
+    if (err && err.code === 'ENOENT') {
+      fs.mkdir(path, function (err) {
+        if (err) {
+          console.error('Could not create the logs path [%s]', path)
+          process.exit(1)
+        }
+      })
+    } else if (!path_stats.isDirectory()) {
+      console.error('The logs path [%s] is not a directory', path)
+      process.exit(1)
+    }
+
+    fs.access(path, fs.W_OK, function (err) {
+      if (err && err.code === 'EACCES') {
+        console.error('The logs path [%s] is not writable', path)
+        process.exit(1)
+      }
+    })
+  })
+}

--- a/test/unit/lib/fs-utils.coffee
+++ b/test/unit/lib/fs-utils.coffee
@@ -1,0 +1,78 @@
+# Test dependencies
+chai      = require 'chai'
+cwd       = process.cwd()
+expect    = chai.expect
+fs        = require 'fs'
+path      = require 'path'
+sinon     = require 'sinon'
+sinonChai = require 'sinon-chai'
+
+# Configure Chai and Sinon
+chai.use sinonChai
+chai.should()
+
+# Code under test
+ensureWritableDirectory = require(path.join(cwd, 'lib/fs-utils')).ensureWritableDirectory
+
+describe 'fs-utils', ->
+
+  describe 'ensureWritableDirectory', ->
+    target_path = 'foo/bar/baz'
+
+    before (done) ->
+      sinon.stub(console, 'error')
+      sinon.stub(process, 'exit')
+      done()
+
+    beforeEach (done) ->
+      sinon.stub(fs, 'access').callsArgWith(2, { code: 'EACCES' })
+      console.error.reset()
+      process.exit.reset()
+      done()
+
+    after ->
+      console.error.restore()
+      process.exit.restore()
+
+    afterEach ->
+      fs.access.restore()
+      fs.stat.restore()
+      fs.mkdir.restore()
+
+    it 'should create the directory if it does not exist', ->
+      sinon.stub(fs, 'mkdir')
+      sinon.stub(fs, 'stat').callsArgWith(1, { code: 'ENOENT' })
+
+      ensureWritableDirectory(target_path)
+
+      fs.stat.should.have.been.calledWithMatch(target_path)
+      fs.mkdir.should.have.been.calledWithMatch(target_path)
+
+    it 'should error out if the directory cannot be created', ->
+      sinon.stub(fs, 'mkdir').callsArgWith(1, {}) # Call callback with an error object
+      sinon.stub(fs, 'stat').callsArgWith(1, { code: 'ENOENT' })
+
+      ensureWritableDirectory(target_path)
+
+      console.error.should.have.been.called
+      process.exit.should.have.been.calledWith(1)
+
+    it 'should error out if the target path is not a directory', ->
+      sinon.stub(fs, 'mkdir')
+      sinon.stub(fs, 'stat').callsArgWith(1, null, { isDirectory: -> false })
+
+      ensureWritableDirectory(target_path)
+
+      console.error.should.have.been.called
+      process.exit.should.have.been.calledWith(1)
+
+    it 'should error out if the target path is not writable', ->
+      sinon.stub(fs, 'mkdir')
+      sinon.stub(fs, 'stat').callsArgWith(1, null, { isDirectory: -> true })
+
+      ensureWritableDirectory(target_path)
+
+      fs.access.should.have.been.calledWith(target_path, fs.W_OK)
+
+      console.error.should.have.been.called
+      process.exit.should.have.been.calledWith(1)


### PR DESCRIPTION
This extracts the functionality for ensuring the `logs` folder exists and is writable. Through this extraction the code can be tested, bringing the coverage of the codebase back up over 80%.

The tests may be an overly explicit, so any refactoring suggestions on that are welcome. It's basically my first time using these libraries, so I had to look up most functionality and am not really aware of best practices surrounding them.