### PR TITLE
provide a new refresh_token with token after refresh

### DIFF
--- a/boot/settings.js
+++ b/boot/settings.js
@@ -430,6 +430,14 @@ settings.op_policy_uri = undefined
 settings.op_tos_uri = undefined
 
 /**
+ * refresh_token_bytes_range
+ *   Define the range of random bytes used to generate the refresh_token
+ *   with crypto.randomBytes
+ */
+
+settings.refresh_token_bytes_range = 10
+
+/**
  * Load config file settings and override defaults
  */
 

--- a/models/AccessToken.js
+++ b/models/AccessToken.js
@@ -151,7 +151,7 @@ AccessToken.mappings.exchange = {
 AccessToken.exchange = function (request, callback) {
   var token = AccessToken.initialize(request.code, { mapping: 'exchange' })
   token.iss = settings.issuer
-  token.rt = random(10)()
+  token.rt = random(settings.refresh_token_bytes_range)()
   this.insert(token, function (err, token) {
     if (err) { return callback(err) }
     callback(null, token)
@@ -214,6 +214,7 @@ AccessToken.refresh = function (refreshToken, clientId, callback) {
       uid: at.uid,
       cid: at.cid,
       ei: at.ei,
+      rt: random(settings.refresh_token_bytes_range)(),
       scope: at.scope
     }, function (err, token) {
       if (err) { return callback(err) }

--- a/test/unit/models/accessTokenSpec.coffee
+++ b/test/unit/models/accessTokenSpec.coffee
@@ -412,6 +412,7 @@ describe 'AccessToken', ->
           ei:      600
           scope:  'openid profile'
         })
+        sinon.spy(AccessToken, 'insert')
         AccessToken.refresh 'r3fr3sh', 'uuid2', (error, result) ->
           err = error
           instance = result
@@ -420,6 +421,7 @@ describe 'AccessToken', ->
       after ->
         multi.exec.restore()
         AccessToken.delete.restore()
+        AccessToken.insert.restore()
         AccessToken.getByRt.restore()
 
       it 'should delete the existing token', ->
@@ -430,6 +432,17 @@ describe 'AccessToken', ->
 
       it 'should provide a new token instance', ->
         expect(instance).to.be.instanceof AccessToken
+
+      it 'should persist the new token instance with a refresh_token and same client_id', ->
+        AccessToken.insert.should.have.been.calledWith sinon.match({
+          cid: 'uuid2'
+          rt: sinon.match.string
+        })
+
+      it 'should provide a new value for the refresh_token', ->
+        AccessToken.insert.should.have.not.been.calledWith sinon.match({
+          rt: 'r3fr3sh'
+        })
 
 
 


### PR DESCRIPTION
Hello,
In the current implementation, we can call the /token with refresh_token grant type only once...
The new token instance doesn't contains a refresh_token, is it on purpose ?
If not may this PR solve this issue :-)
Regards,
Camille