### PR TITLE
feat(signin) : add request headers available to signin and signup view

### DIFF
--- a/routes/signin.js
+++ b/routes/signin.js
@@ -13,13 +13,13 @@ var providers = require('../providers')
 var providerInfo = {}
 var providerNames = Object.keys(providers)
 for (var i = 0; i < providerNames.length; i++) {
-  providerInfo[providerNames[i]] = providers[providerNames[i]]
+  providerInfo[ providerNames[ i ] ] = providers[ providerNames[ i ] ]
 }
 var visibleProviders = {}
 // Only render providers that are not marked as hidden
 Object.keys(settings.providers).forEach(function (providerID) {
-  if (!settings.providers[providerID].hidden) {
-    visibleProviders[providerID] = settings.providers[providerID]
+  if (!settings.providers[ providerID ].hidden) {
+    visibleProviders[ providerID ] = settings.providers[ providerID ]
   }
 })
 
@@ -40,6 +40,7 @@ module.exports = function (server) {
       res.render('signin', {
         params: qs.stringify(req.query),
         request: req.query,
+        headers: req.headers,
         providers: visibleProviders,
         providerInfo: providerInfo,
         mailSupport: !!(mailer.transport)

--- a/routes/signin.js
+++ b/routes/signin.js
@@ -40,7 +40,7 @@ module.exports = function (server) {
       res.render('signin', {
         params: qs.stringify(req.query),
         request: req.query,
-        headers: req.headers,
+        referer: req.headers['referer'],
         providers: visibleProviders,
         providerInfo: providerInfo,
         mailSupport: !!(mailer.transport)

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -29,7 +29,7 @@ module.exports = function (server) {
       res.render('signup', {
         params: qs.stringify(req.query),
         request: req.query,
-        headers: req.headers,
+        referer: req.headers['referer'],
         providers: settings.providers
       })
     }

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -29,6 +29,7 @@ module.exports = function (server) {
       res.render('signup', {
         params: qs.stringify(req.query),
         request: req.query,
+        headers: req.headers,
         providers: settings.providers
       })
     }


### PR DESCRIPTION
Useful to get cookie, referer, etc if needed for the signin/signup form
