### PR TITLE
authorizedScope, allow for no role scopes

### DIFF
--- a/models/Client.js
+++ b/models/Client.js
@@ -791,6 +791,11 @@ Client.prototype.authorizedScope = function (callback) {
 
     multi.exec(function (err, results) {
       if (err) { return callback(err) }
+      
+      if (!results || results.length === 0) {
+        return callback(null, [])
+      }
+
       callback(null, results.map(function (result) {
         return result[1][0]
       }))


### PR DESCRIPTION
not allowing for this case can cause a crash