### PR TITLE
Make npm test work out of the box.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
   ],
   "scripts": {
     "start": "node server.js",
-    "test": "eslint --ignore-path .gitignore . && echo Code looks good! && mocha test/unit",
+    "test": "eslint --ignore-path .gitignore . && echo Code looks good! && NODE_ENV=test mocha test/unit",
     "lint": "eslint --ignore-path .gitignore . && echo Code looks good!",
-    "test-watch": "mocha test/unit --watch",
-    "test-integration": "mocha test/integration",
-    "test-integration-watch": "mocha test/integration --watch",
+    "test-watch": "NODE_ENV=test mocha test/unit --watch",
+    "test-integration": "NODE_ENV=test mocha test/integration",
+    "test-integration-watch": "NODE_ENV=test mocha test/integration --watch",
     "test-all": "mocha test/unit && mocha test/integration",
     "coverage": "NODE_ENV=test istanbul cover _mocha -- test/"
   },


### PR DESCRIPTION
This only adds `NODE_ENV=test` for test scripts in package.json so that

    $ git clone $anvil_connect_uri && cd connect && npm install && npm test

works!