### PR TITLE
feat(state param signout): add state param for signout redirect like authorize

### DIFF
--- a/oidc/signout.js
+++ b/oidc/signout.js
@@ -40,6 +40,9 @@ function signout (req, res, next) {
       // logout and redirect
       } else {
         authenticator.logout(req)
+        if (req.query.state) {
+          uri += '?state=' + req.query.state
+        }
         res.redirect(uri)
       }
     })

--- a/test/unit/oidc/signout.coffee
+++ b/test/unit/oidc/signout.coffee
@@ -158,6 +158,7 @@ describe 'Signout', ->
             query:
               post_logout_redirect_uri: 'http://example.com'
               id_token_hint: validIDToken
+              state: 'encodedState'
             session:
               opbs: opbs
               amr: ['otp']
@@ -184,8 +185,8 @@ describe 'Signout', ->
         it 'should not respond 204', ->
           res.send.should.not.have.been.calledWith 204
 
-        it 'should redirect', ->
-          res.redirect.should.have.been.calledWith req.query.post_logout_redirect_uri
+        it 'should redirect with state param', ->
+          res.redirect.should.have.been.calledWith req.query.post_logout_redirect_uri + '?state='+req.query.state
 
 
     describe 'with invalid token', ->


### PR DESCRIPTION
it enable the same possibility as the state param in authorize query param, to give the client the possibility to keep a state and retrieve it after logout