### PR TITLE
Add response_mode hidden field to authorize view

### DIFF
--- a/views/authorize.jade
+++ b/views/authorize.jade
@@ -27,6 +27,8 @@ html(lang="en")
             li= scope.description
 
         form.singlebutton(action='/authorize', method='POST')
+          if request.response_mode
+            input(type='hidden', name='response_mode', value=request.response_mode)
           input(type='hidden', name='response_type', value=request.response_type)
           input(type='hidden', name='client_id', value=request.client_id)
           input(type='hidden', name='redirect_uri', value=request.redirect_uri)


### PR DESCRIPTION
For implicit auth requests with non-trusted clients, users are presented with the Authorization / consent screen. The `response_mode` hidden field was missing on the template, so the response mode defaulted to `fragment` or whatever. 

This adds the missing field.