### PR TITLE
fix(oidc): ensure role present and has name attr

### DIFF
--- a/oidc/requireVerifiedEmail.js
+++ b/oidc/requireVerifiedEmail.js
@@ -34,7 +34,7 @@ module.exports = function (options) {
       if (err) { return next(err) }
 
       var isAuthority = roles && roles.some(function (role) {
-        return role.name === 'authority'
+        return role && role.name && role.name === 'authority'
       })
 
       if (req.user.emailVerified || isAuthority) {


### PR DESCRIPTION
In some cases, I was getting a `null` value back for a `role` returned in the `listByUsers` callback.

I am working on figuring out what the issue in the underlying database is, but this guards against it in the event that it occurs.