### PR TITLE
verifyClient  : add test on missing client redirect_uris in database

### DIFF
--- a/oidc/verifyClient.js
+++ b/oidc/verifyClient.js
@@ -53,7 +53,7 @@ function verifyClient (req, res, next) {
     req.client = client
 
     // Redirect URI must be configured for this client.
-    if (client.redirect_uris.indexOf(params.redirect_uri) === -1) {
+    if (!client.redirect_uris || client.redirect_uris.indexOf(params.redirect_uri) === -1) {
       return next(new AuthorizationError({
         error: 'invalid_request',
         error_description: 'Mismatching redirect uri',

--- a/test/unit/oidc/verifyClient.coffee
+++ b/test/unit/oidc/verifyClient.coffee
@@ -135,3 +135,35 @@ describe 'Verify Client', ->
 
     it 'should provide a status code', ->
       err.statusCode.should.equal 400
+
+
+  describe 'with client without redirect uri', ->
+
+    before (done) ->
+      client = {}
+      sinon.stub(Client, 'get').callsArgWith(2, null, client)
+      req =
+        connectParams:
+          redirect_uri: 'https://redirect.uri/cb'
+          client_id: 'id'
+      res  = {}
+      next = sinon.spy()
+
+      verifyClient req, res, (error) ->
+        err = error
+        done()
+
+    after ->
+      Client.get.restore()
+
+    it 'should provide an AuthorizationError', ->
+      err.name.should.equal 'AuthorizationError'
+
+    it 'should provide an error code', ->
+      err.error.should.equal 'invalid_request'
+
+    it 'should provide an error description', ->
+      err.error_description.should.equal 'Mismatching redirect uri'
+
+    it 'should provide a status code', ->
+      err.statusCode.should.equal 400


### PR DESCRIPTION
Hello,

I've got this issue two times in the past days :

TypeError: Cannot read property 'indexOf' of undefined
    at /node_modules/anvil-connect/oidc/verifyClient.js:56:29
...

I have only 2 clients configured (Anvil Client and my own) and redirect_uris are configured for both... So I assume it comes from the Redis server (cluster mode) but the result is a crash of the node instances. This PR can prevent this.

Regards,
Camille