### PR TITLE
fix(logger) default logger.js location

### DIFF
--- a/boot/logger.js
+++ b/boot/logger.js
@@ -115,7 +115,7 @@ module.exports = function (options) {
     }
 
     try {
-      config = require('../logger')
+      config = require(path.join(cwd, 'logger'))
     } catch (e) {
       if (e.code !== 'MODULE_NOT_FOUND') { throw e }
     }


### PR DESCRIPTION
Currently a custom logger.js file is expected to be found in the anvil-connect node package root - if a logger.js file is added there it's deleted every time node_modules is reinstalled.

As discussed in the original commit here: https://github.com/anvilresearch/connect/commit/68ba379e4355ae70b36ea2d1a0f1ddf18b90a562 this PR changes the behaviour to look relative to where anvil is being run from.