### PR TITLE
Bump express-bunyan-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cookie-parser": "^1.3.4",
     "cors": "^2.6.0",
     "express": "^4.12.3",
-    "express-bunyan-logger": "^1.1.1",
+    "express-bunyan-logger": "^1.3.0",
     "express-session": "^1.11.1",
     "glob": "^7.0.3",
     "hogan.js": "^3.0.2",


### PR DESCRIPTION
The latest version of express-bunyan-logger includes the option to obfuscate specific fields based on patterns. 

This is really useful if you want to hide the body.password field which is currently logged by for failed signin attempts. Often users type their email in incorrectly but their password correctly so their valid password will be left hanging around in log files.

Will update docs with example of obfuscating as well.