### PR TITLE
The at_hash in id_tokens does not follow the spec

### DIFF
--- a/oidc/authorize.js
+++ b/oidc/authorize.js
@@ -11,6 +11,7 @@ var AccessToken = require('../models/AccessToken')
 var AuthorizationCode = require('../models/AuthorizationCode')
 var nowSeconds = require('../lib/time-utils').nowSeconds
 var sessionState = require('../oidc/sessionState')
+var base64url = require('base64url')
 
 /**
  * Authorize
@@ -78,7 +79,7 @@ function authorize (req, res, next) {
             shasum = crypto.createHash('sha256')
             shasum.update(response.access_token)
             hash = shasum.digest('hex')
-            atHash = hash.slice(0, hash.length / 2)
+            atHash = base64url(new Buffer(hash.substring(0, hash.length / 2), 'hex'))
           }
 
           var idToken = new IDToken({


### PR DESCRIPTION
The spec for generating an at_hash can be seen on http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.2.2.10

The existing code does not base64 encode the hash and therefore all existing id_token token flows should fail. Any clients that use this flow with anvil currently are breaking the standard.