### PR TITLE
add a state parameter to authentication error response

### DIFF
--- a/oidc/requireSignin.js
+++ b/oidc/requireSignin.js
@@ -21,6 +21,7 @@ function requireSignin (req, res, next) {
   if (!req.user && prompt === 'none') {
     res.redirect(req.connectParams.redirect_uri + responseMode + qs.stringify({
       error: 'login_required',
+      state: req.connectParams.state,
       session_state: sessionState(req.client, req.client.client_uri, req.session.opbs)
     }))
 


### PR DESCRIPTION
Hello

> OAuth 2.0 state value REQUIRED if the Authorization Request included the state parameter.

[3.1.2.6.  Authentication Error Response](http://openid.net/specs/openid-connect-core-1_0.html#AuthError)
[3.2.2.6.  Authentication Error Response](http://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthError)