### PR TITLE
fix(error_handling): handle the exception that could be thrown by the call to  'toJWT'

### DIFF
--- a/models/AccessToken.js
+++ b/models/AccessToken.js
@@ -184,7 +184,11 @@ AccessToken.issue = function (request, callback) {
     // Unless the client is set to issue a random token,
     // transform it to a signed JWT.
     if (request.client.access_token_type !== 'random') {
-      response.access_token = token.toJWT(settings.keys.sig.prv)
+      try {
+        response.access_token = token.toJWT(settings.keys.sig.prv)
+      } catch (err) {
+        return callback(err)
+      }
     }
 
     callback(null, response)

--- a/test/unit/models/accessTokenSpec.coffee
+++ b/test/unit/models/accessTokenSpec.coffee
@@ -247,25 +247,54 @@ describe 'AccessToken', ->
 
     describe 'with invalid request', ->
 
-      before (done) ->
-        sinon.stub(AccessToken, 'insert').callsArgWith(1, new Error)
-        req =
-          user: {}
-          client: {}
-        AccessToken.issue req, (error, response) ->
-          err = error
-          res = response
-          done()
+      describe 'with insert exception', ->
 
-      after ->
-        AccessToken.insert.restore()
+        before (done) ->
+          sinon.stub(AccessToken, 'insert').callsArgWith(1, new Error)
+          req =
+            user: {}
+            client: {}
+          AccessToken.issue req, (error, response) ->
+            err = error
+            res = response
+            done()
 
-      it 'should provide an error', ->
-        expect(err).to.be.an('Error')
+        after ->
+          AccessToken.insert.restore()
 
-      it 'should not provide a value', ->
-        expect(res).to.equal undefined
+        it 'should provide an error', ->
+          expect(err).to.be.an('Error')
 
+        it 'should not provide a value', ->
+          expect(res).to.equal undefined
+
+      describe 'with toJWT exception', ->
+
+        before (done) ->
+          instance = new AccessToken
+            iss: settings.issuer
+            uid: 'uuid1'
+            cid: 'uuid2'
+            scope: 'openid profile'
+          sinon.stub(AccessToken, 'insert').callsArgWith(1, null, instance)
+          sinon.stub(AccessToken.prototype, 'toJWT').throws(new Error)
+          req =
+            user: {}
+            client: {}
+          AccessToken.issue req, (error, response) ->
+            err = error
+            res = response
+            done()
+
+        after ->
+          AccessToken.insert.restore()
+          AccessToken.prototype.toJWT.restore()
+
+        it 'should provide an error', ->
+          expect(err).to.be.an('Error')
+
+        it 'should not provide a value', ->
+          expect(res).to.equal undefined
 
     describe 'with valid request', ->
 


### PR DESCRIPTION
Hi,

The POST on /signin with malformed scope list make the instance crash !!
It can be reproduced with this value :  scope=openid%20profile%email
This PR avoid the crash.

Regards,
Camille
