### PR TITLE
Fixes for invalid token and collects email, etc.

### DIFF
--- a/providers/facebook.js
+++ b/providers/facebook.js
@@ -11,17 +11,16 @@ module.exports = function (config) {
     redirect_uri: config.issuer + '/connect/facebook/callback',
     endpoints: {
       authorize: {
-        url: 'https://www.facebook.com/dialog/oauth',
+        url: 'https://www.facebook.com/v2.8/dialog/oauth',
         method: 'POST'
       },
       token: {
-        url: 'https://graph.facebook.com/oauth/access_token',
+        url: 'https://graph.facebook.com/v2.8/oauth/access_token',
         method: 'POST',
-        auth: 'client_secret_post',
-        parser: 'x-www-form-urlencoded'
+        auth: 'client_secret_post'
       },
       user: {
-        url: 'https://graph.facebook.com/me',
+        url: 'https://graph.facebook.com/me?fields=name,first_name,last_name,link,gender,locale,verified,picture,email',
         method: 'GET',
         auth: {
           header: 'Authorization',
@@ -34,11 +33,12 @@ module.exports = function (config) {
       id: 'id',
       emailVerified: 'verified',
       name: 'name',
+      email: 'email',
+      picture: 'picture.data.url',
       givenName: 'first_name',
       familyName: 'last_name',
       profile: 'link',
       gender: 'gender',
-      // zoneinfo:       'timezone',
       locale: 'locale'
     }
   }


### PR DESCRIPTION
- using a specific version of the API rather than the "oldest available".
- removed the x-www form encoding thing for the token parser .. facebook doesn't use that anymore since it returns json.
- added all of the missing files that should be there. Requires provider config for facebook to have "scope": ["email"] in your configuration.
- set a specific API version to use, otherwise it uses the oldest, which may become deprecated in the future and newer versions may break this provider file.