### PR TITLE
fix(protocols): incorrectly renamed request param

### DIFF
--- a/protocols/OAuth2.js
+++ b/protocols/OAuth2.js
@@ -177,7 +177,7 @@ function authorizationCodeGrant (code, done) {
   // required token parameters
   params.grant_type = 'authorization_code'
   params.code = code
-  params.redirectUri = provider.redirect_uri
+  params.redirect_uri = provider.redirect_uri
 
   // start building the request
   var req = request[method || 'post'](url)

--- a/protocols/OAuth2.js
+++ b/protocols/OAuth2.js
@@ -127,7 +127,7 @@ function authorizationRequest (req, options) {
   var config = this.client
   var url = URL.parse(endpoints.authorize.url)
   var responseType = 'code'
-  var clientId = config.clientId
+  var clientId = config.client_id
   var redirectUri = provider.redirect_uri
   var state = options.state
 

--- a/test/unit/strategies/OAuth2.coffee
+++ b/test/unit/strategies/OAuth2.coffee
@@ -50,7 +50,7 @@ describe 'OAuth2 Strategy', ->
       name: 'name'
 
   config =
-    clientId:      'id',
+    client_id:      'id',
     client_secret:  'secret'
     scope:          ['c']
 
@@ -216,7 +216,7 @@ describe 'OAuth2 Strategy', ->
 
       it 'should include client_id', ->
         strategy.redirect.should.have.been.calledWith sinon.match(
-          'client_id=' + config.clientId
+          'client_id=' + config.client_id
         )
       it 'should include redirect_uri', ->
         strategy.redirect.should.have.been.calledWith sinon.match(


### PR DESCRIPTION
It appears `redirectUri` is expected to be `redirect_uri`. The rename in the recent update to get test working again broke Google Authentication when the client library tries to retrieve a token using the code Google returns.